### PR TITLE
Upgrading Redisson version

### DIFF
--- a/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/test/java/co/elastic/apm/agent/redis/AbstractRedisInstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/test/java/co/elastic/apm/agent/redis/AbstractRedisInstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -46,6 +46,15 @@ import static org.awaitility.Awaitility.await;
 public abstract class AbstractRedisInstrumentationTest extends AbstractInstrumentationTest {
     protected RedisServer server;
     protected int redisPort;
+    private String expectedAddress;
+
+    public AbstractRedisInstrumentationTest() {
+        this.expectedAddress = "localhost";
+    }
+
+    public AbstractRedisInstrumentationTest(String expectedAddress) {
+        this.expectedAddress = expectedAddress;
+    }
 
     private static int getAvailablePort() throws IOException {
         try (ServerSocket socket = ServerSocketFactory.getDefault().createServerSocket(0, 1, InetAddress.getByName("localhost"))) {
@@ -84,7 +93,7 @@ public abstract class AbstractRedisInstrumentationTest extends AbstractInstrumen
         for (Span span : spanList) {
             Destination destination = span.getContext().getDestination();
             if (destinationAddressSupported()) {
-                assertThat(destination.getAddress().toString()).isEqualTo("localhost");
+                assertThat(destination.getAddress().toString()).isEqualTo(expectedAddress);
                 assertThat(destination.getPort()).isEqualTo(redisPort);
             }
             Destination.Service service = destination.getService();

--- a/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.redisson</groupId>
             <artifactId>redisson</artifactId>
-            <version>3.3.2</version>
+            <version>3.12.3</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/src/test/java/co/elastic/apm/agent/redis/redisson/RedissonInstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/src/test/java/co/elastic/apm/agent/redis/redisson/RedissonInstrumentationTest.java
@@ -50,10 +50,14 @@ class RedissonInstrumentationTest extends AbstractRedisInstrumentationTest {
 
     protected RedissonClient redisson;
 
+    public RedissonInstrumentationTest() {
+        super("127.0.0.1");
+    }
+
     @BeforeEach
     void setUp() {
         Config config = new Config();
-        config.useSingleServer().setAddress("localhost:" + redisPort);
+        config.useSingleServer().setAddress("redis://localhost:" + redisPort);
         redisson = Redisson.create(config);
     }
 
@@ -99,7 +103,7 @@ class RedissonInstrumentationTest extends AbstractRedisInstrumentationTest {
             assertThat(strings.get(0)).isEqualTo("a");
         }
 
-        assertTransactionWithRedisSpans("RPUSH", "LLEN", "LLEN", "LINDEX");
+        assertTransactionWithRedisSpans("RPUSH", "LLEN", "LINDEX");
     }
 
     @Test
@@ -152,7 +156,7 @@ class RedissonInstrumentationTest extends AbstractRedisInstrumentationTest {
             assertThat(atomicLong.get()).isEqualTo(1);
         }
 
-        assertTransactionWithRedisSpans("INCR", "INCRBY");
+        assertTransactionWithRedisSpans("INCR", "GET");
     }
 
     /**

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -415,7 +415,7 @@ you should add an additional entry to this list (make sure to also include the d
 ==== `disable_instrumentations`
 
 A list of instrumentations which should be disabled.
-Valid options are `annotations`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `concurrent`, `elasticsearch-restclient`, `exception-handler`, `executor`, `hibernate-search`, `http-client`, `incubating`, `jax-rs`, `jax-ws`, `jdbc`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log4j`, `logging`, `mongodb-client`, `mule`, `okhttp`, `opentracing`, `process`, `public-api`, `quartz`, `redis`, `render`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-input-stream`, `slf4j`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `urlconnection`.
+Valid options are `annotations`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `concurrent`, `elasticsearch-restclient`, `exception-handler`, `executor`, `hibernate-search`, `http-client`, `incubating`, `jax-rs`, `jax-ws`, `jdbc`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log4j`, `logging`, `mongodb-client`, `mule`, `okhttp`, `opentracing`, `process`, `public-api`, `quartz`, `redis`, `redisson`, `render`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-input-stream`, `slf4j`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `urlconnection`.
 If you want to try out incubating features, set the value to an empty string.
 
 
@@ -1974,7 +1974,7 @@ The default unit for this option is `ms`.
 # sanitize_field_names=password,passwd,pwd,secret,*key,*token*,*session*,*credit*,*card*,authorization,set-cookie
 
 # A list of instrumentations which should be disabled.
-# Valid options are `annotations`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `concurrent`, `elasticsearch-restclient`, `exception-handler`, `executor`, `hibernate-search`, `http-client`, `incubating`, `jax-rs`, `jax-ws`, `jdbc`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log4j`, `logging`, `mongodb-client`, `mule`, `okhttp`, `opentracing`, `process`, `public-api`, `quartz`, `redis`, `render`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-input-stream`, `slf4j`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `urlconnection`.
+# Valid options are `annotations`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `concurrent`, `elasticsearch-restclient`, `exception-handler`, `executor`, `hibernate-search`, `http-client`, `incubating`, `jax-rs`, `jax-ws`, `jdbc`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log4j`, `logging`, `mongodb-client`, `mule`, `okhttp`, `opentracing`, `process`, `public-api`, `quartz`, `redis`, `redisson`, `render`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-input-stream`, `slf4j`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `urlconnection`.
 # If you want to try out incubating features, set the value to an empty string.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.


### PR DESCRIPTION
@dengliming there is an inconsistency with the Jackson version brought by the Redisson version you used and the one used by the MockReporter. There are other solutions for that, but I opted for using the latest Redisson version for testing, which required some additional changes.
Another required change was the auto-created `configuration.asciidoc` file.
Please review and see if the changes make sense.